### PR TITLE
Fix test timeouts (and slight restructure)

### DIFF
--- a/catalog.tests.bom
+++ b/catalog.tests.bom
@@ -33,34 +33,32 @@ brooklyn.catalog:
         id: jboss7
 
       - type: test-case
+        name: JBoss AS 7 Tests
         brooklyn.config:
-          timeout: 15m
           targetId: jboss7
-        name: JBoss Application Server 7 Tests
+          timeout: 15m
 
         brooklyn.children:
-        - type: test-case
-          name: "Sensor Tests"
-          brooklyn.children:
-          # Is up and can deploy
-          - type: assert-running
-          - type: invoke-effector
-            name: Invoke Deploy Effector
-            effector: deploy
-            params:
-              url: https://tomcat.apache.org/tomcat-8.0-doc/appdev/sample/sample.war
-              targetName: sample
+
+        - type: assert-up-and-running-initial
+          name: "1 Node up and running"
+
+        - type: invoke-effector
+          name: Invoke Deploy Effector
+          effector: deploy
+          params:
+            url: https://tomcat.apache.org/tomcat-8.0-doc/appdev/sample/sample.war
+            targetName: sample
         
         - type: test-case
           name: "Effector Restart, Stop & Restart Tests"
-          brooklyn.children:      
-          # Effector: restart Tests
+          brooklyn.children:
+
           - type: assert-restart-process
             name: "1. restart process"
             brooklyn.config:
               process.grep.name: "[Jj]boss"
 
-          # Effector: stop + restart Tests
           - type: assert-stop-and-restart-process
             name: "2. stop and restart process"
             brooklyn.config:
@@ -74,13 +72,11 @@ brooklyn.catalog:
           - type: test-http-status-200
             name: Check Servlet HTTP Response Status Code
             url: >
-              $brooklyn:formatString("http://%s:%s/sample/hello",
-              $brooklyn:component("jboss7").attributeWhenReady("host.address"),
-              $brooklyn:component("jboss7").attributeWhenReady("http.port"))
+              $brooklyn:formatString("%s/sample/hello",
+              $brooklyn:component("jboss7").attributeWhenReady("main.uri"))
 
           - type: test-http-status-200
             name: Check JSP HTTP Response Status Code
             url: >
-              $brooklyn:formatString("http://%s:%s/sample/hello.jsp",
-              $brooklyn:component("jboss7").attributeWhenReady("host.address"),
-              $brooklyn:component("jboss7").attributeWhenReady("http.port"))
+              $brooklyn:formatString("%s/sample/hello.jsp",
+              $brooklyn:component("jboss7").attributeWhenReady("main.uri"))


### PR DESCRIPTION
When I tried the test locally (on ibm-bluebox centos7), the `assert-running` timeout out after 15 minutes. However, the process subsequently did come up.

This PR changes it to use the better `assert-up-and-running-initial`, which defaults to a 1h timeout for the initial provisioning.